### PR TITLE
Add continuous integration

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,3 +2,5 @@
 ^\.Rproj\.user$
 ^output*
 ^NEWS\.md$
+^\.travis\.yml$
+^appveyor\.yml$

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,37 @@
+## .travis.yml file for use with metacran/r-builder
+## See https://github.com/metacran/r-builder for details.
+
+language: c
+
+sudo: required
+
+before_install:
+  - curl -OL https://raw.githubusercontent.com/metacran/r-builder/master/pkg-build.sh
+  - chmod 755 pkg-build.sh
+  - ./pkg-build.sh bootstrap
+
+install:
+  - ./pkg-build.sh install_bioc_deps
+  - ./pkg-build.sh install_github jimhester/covr
+
+script:
+   - ./pkg-build.sh run_tests
+
+after_success:
+  - ./pkg-build.sh run_script -e 'covr::codecov()'
+
+after_failure:
+  - ./pkg-build.sh dump_logs
+
+notifications:
+  email:
+    on_success: change
+    on_failure: change
+
+env:
+  global:
+    - BOOTSTRAP_LATEX=true # Required to build pdf vignettes (+ manual); slower
+    - R_CHECK_ARGS="--no-vignettes --timings" # Mimic BioC build machines
+  matrix:
+    - RVERSION=devel # BioC 3.3 uses R 3.3.x (R-devel at the time of writing).
+                     # This needs to be manually updated upon new BioC version.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # scater: single-cell analysis toolkit for expression with R
 
+[![Linux Build Status](https://travis-ci.org/davismcc/scater.svg?branch=master)](https://travis-ci.org/davismcc/scater)
+[![Windows Build status](https://ci.appveyor.com/api/projects/status/github/davismcc/scater?svg=true)](https://ci.appveyor.com/project/davismcc/scater)
+[![Coverage Status](https://img.shields.io/codecov/c/github/davismcc/scater/master.svg)](https://codecov.io/github/davismcc/scater?branch=master)
+
 This package contains useful tools for the analysis of single-cell
 gene expression data using the statistical software R. The package places an
 emphasis on tools for quality control, visualisation and pre-processing of data

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,41 @@
+# DO NOT CHANGE the "init" and "install" sections below
+
+# Download script file from GitHub
+init:
+  ps: |
+        $ErrorActionPreference = "Stop"
+        Invoke-WebRequest http://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
+        Import-Module '..\appveyor-tool.ps1'
+
+install:
+  ps: Bootstrap
+
+# Adapt as necessary starting from here
+
+build_script:
+  - travis-tool.sh install_bioc_deps
+
+test_script:
+   - travis-tool.sh run_tests
+
+on_failure:
+  - travis-tool.sh dump_logs
+
+artifacts:
+  - path: '*.Rcheck\**\*.log'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.out'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.fail'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.Rout'
+    name: Logs
+
+  - path: '\*_*.tar.gz'
+    name: Bits
+
+  - path: '\*_*.zip'
+    name: Bits


### PR DESCRIPTION
Hey Davis,

This PR adds continuous integration using Travis (linux) and AppVeyor (Windows) using R 3.3. It also adds code coverage using www.codecov.io and Jim Hester's [covr](https://github.com/jimhester/covr) package. It also adds badges for these services to `README.md`. 

Under the assumption that you're targeting the next Bioconductor release, these build using R 3.3  - happy to help if you also want to build against R 3.2.x

**What you'll need to do**
- Sign up for https://travis-ci.org/, http://www.appveyor.com/, and https://codecov.io/ and flick the appropriate switches for scater.

**Limitations**
- I don't yet have any CI running on my packages for OS X, but since I develop on a mac I don't mind this much. 
