### PR TITLE
Fixed floating point overflow for very small numbers (<e-300)

### DIFF
--- a/R/kallisto-wrapper.R
+++ b/R/kallisto-wrapper.R
@@ -227,7 +227,9 @@ readKallistoResultsOneSample <- function(directory, read_h5=FALSE,
     else
         file_to_read <- paste0(directory, "/abundance.tsv")
     if ( file.exists(file_to_read) )
-        abundance <- data.table::fread(file_to_read, sep = "\t")
+        abundance <- data.table::fread(file_to_read, colClasses = c("numeric", "numeric", "numeric", "character", "character"), sep = "\t")
+        abundance$est_counts <- as.numeric(abundance$est_counts)
+        abundance$tpm <- as.numeric(abundance$tpm)
     else
         stop(paste("File", file_to_read, "not found or does not exist. Please check directory is correct."))
     ## Read in run information


### PR DESCRIPTION
Read Kallisto count data as characters, then typecast to numeric. This effectively rounds very small numbers to zero, preventing fread() from throwing overflow error.
