### PR TITLE
Added warning to sizeFactors().

### DIFF
--- a/R/SCESet-methods.R
+++ b/R/SCESet-methods.R
@@ -1244,9 +1244,17 @@ setReplaceMethod("norm_fpkm", signature(object = "SCESet", value = "matrix"),
 #' data("sc_example_cell_info")
 #' example_sceset <- newSCESet(countData = sc_example_counts)
 #' sizeFactors(example_sceset)
+#' sizeFactors(example_sceset) <- 2^rnorm(ncol(example_sceset))
+#' sizeFactors(example_sceset)
 #'
 sizeFactors.SCESet <- function(object) {
-    object$size_factors
+    out <- object$size_factors
+    if (is.null(out)) { 
+        warning("'sizeFactors' have not been set") 
+        return(NULL)
+    }
+    names(out) <- colnames(object) 
+    return(out)
 }
 
 #' @name sizeFactors


### PR DESCRIPTION
Also added names to the returned vector of size factors, which is occasionally useful. On a related note, consider setting value="numeric" in the assignment method, and maybe adding another method for value="NULL" (just in case someone wants to clear the size factors, so that the object is reset to the state where no size factors exist - then it's clear that size factors need to be added, rather than people accidentally using incorrect size factors). It's too bad we don't have a `numericOrNULL` class.
