### PR TITLE
Remove transcript ID artifacts from kallisto output

### DIFF
--- a/R/feature-preprocessing.R
+++ b/R/feature-preprocessing.R
@@ -71,6 +71,8 @@ getBMFeatureAnnos <- function(object, filters="ensembl_transcript_id",
                                   host = host) 
     ## Define feature IDs from SCESet object
     feature_ids <- featureNames(object)
+    ## Remove transcript ID artifacts from runKallisto (eg. ENSMUST00000201087.11 -> ENSMUST00000201087)
+    feature_ids <- gsub(pattern = "\\.[0-9]+", replacement = "", x = feature_ids)
     ## Get annotations from biomaRt
     feature_info <- biomaRt::getBM(attributes = attributes, 
                                    filters = filters, 


### PR DESCRIPTION
For whatever reason runKallisto adds additional numerics onto the end of transcript IDs. This fix removes these artifacts when running getBMFeatureAnnos.
