### PR TITLE
Added support for subsetting in efficient top calculation 

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -10,7 +10,7 @@ static const R_CallMethodDef all_call_entries[] = {
     REGISTER(rowsum_exprs, 2),
     REGISTER(negative_counts, 1),
     REGISTER(missing_exprs, 1),
-    REGISTER(calc_top_features, 2),
+    REGISTER(calc_top_features, 3),
     {NULL, NULL, 0}
 };
 

--- a/src/scater.h
+++ b/src/scater.h
@@ -40,7 +40,7 @@ SEXP colsum_exprs_subset(SEXP, SEXP, SEXP);
 
 SEXP rowsum_exprs(SEXP, SEXP);
 
-SEXP calc_top_features(SEXP, SEXP);
+SEXP calc_top_features(SEXP, SEXP, SEXP);
 
 SEXP negative_counts(SEXP);
 


### PR DESCRIPTION
As the name suggests, related to issue #65. I haven't tested this thoroughly, but it seems to work.
