### PR TITLE
getBMFeatureAnnos: attributes arg dynamically linked to feature_symbo…

### DIFF
--- a/R/feature-preprocessing.R
+++ b/R/feature-preprocessing.R
@@ -54,7 +54,7 @@
 #' 
 getBMFeatureAnnos <- function(object, filters="ensembl_transcript_id", 
                               attributes=c("ensembl_transcript_id", 
-                                           "ensembl_gene_id", "mgi_symbol", 
+                                           "ensembl_gene_id", feature_symbol, 
                                            "chromosome_name", "transcript_biotype",
                                            "transcript_start", "transcript_end", 
                                            "transcript_count"), 

--- a/man/getBMFeatureAnnos.Rd
+++ b/man/getBMFeatureAnnos.Rd
@@ -5,7 +5,7 @@
 \title{Get feature annotation information from Biomart}
 \usage{
 getBMFeatureAnnos(object, filters = "ensembl_transcript_id",
-  attributes = c("ensembl_transcript_id", "ensembl_gene_id", "mgi_symbol",
+  attributes = c("ensembl_transcript_id", "ensembl_gene_id", feature_symbol,
   "chromosome_name", "transcript_biotype", "transcript_start", "transcript_end",
   "transcript_count"), feature_symbol = "mgi_symbol",
   feature_id = "ensembl_gene_id", biomart = "ENSEMBL_MART_ENSEMBL",


### PR DESCRIPTION
In the method `getBMFeatureAnnos`, these changes dynamically link the `attributes` argument  to the `feature_symbol` argument. Users only have to change the latter to automatically update the former (otherwise `biomaRt::getBM` complains).
