### PR TITLE
Started streamlining normalization, recalculation functions

### DIFF
--- a/R/AllGenerics.R
+++ b/R/AllGenerics.R
@@ -234,6 +234,22 @@ setGeneric("featDist<-", function(object, value) {
     standardGeneric("featDist<-")
 })
 
+#' @name featureControlInfo
+#' @export
+#' @docType methods
+#' @rdname featureControlInfo 
+setGeneric("featureControlInfo", function(object) {
+    standardGeneric("featureControlInfo")
+})
+
+#' @name featureControlInfo<-
+#' @export
+#' @docType methods
+#' @rdname featureControlInfo
+setGeneric("featureControlInfo<-", function(object, value) {
+    standardGeneric("featureControlInfo<-")
+})
+
 
 #' @name reducedDimension
 #' @export

--- a/R/AllGenerics.R
+++ b/R/AllGenerics.R
@@ -11,7 +11,7 @@ setGeneric("cellNames<-", function(object, value) {standardGeneric("cellNames<-"
 #' @docType methods
 #' @return a matrix of expression values
 #' @rdname get_exprs
-setGeneric("get_exprs", function(object, exprs_values) {
+setGeneric("get_exprs", function(object, exprs_values, ...) {
     standardGeneric("get_exprs")})
 
 #' @name set_exprs<-

--- a/R/SCESet-methods.R
+++ b/R/SCESet-methods.R
@@ -585,7 +585,7 @@ setReplaceMethod("pData", signature(object = "SCESet", value = "data.frame"),
 #' assayData slot of the SCESet object.
 #'
 #' @usage
-#' \S4method{get_exprs}{SCESet}(object, exprs_values)
+#' \S4method{get_exprs}{SCESet}(object, exprs_values, warning = TRUE)
 #'
 #' @docType methods
 #' @name get_exprs
@@ -620,11 +620,11 @@ setReplaceMethod("pData", signature(object = "SCESet", value = "data.frame"),
 #' colSums(counts(example_sceset)))
 #' get_exprs(example_sceset, "scaled_counts")[1:6, 1:6]
 #'
-get_exprs.SCESet <- function(object, exprs_values = "exprs", warning=TRUE) {
+get_exprs.SCESet <- function(object, exprs_values = "exprs", warning = TRUE) {
     exprs_mat <- object@assayData[[exprs_values]]
 
     if ( is.null(exprs_mat) ) {
-        msg <- sprintf("'object' does not contain '%s'", exprs_values)
+        msg <- sprintf("'object' does not contain '%s' values", exprs_values)
         if (warning) {
             warning(paste0(msg, ", returning NULL"))
         } else {
@@ -638,8 +638,8 @@ get_exprs.SCESet <- function(object, exprs_values = "exprs", warning=TRUE) {
 #' @rdname get_exprs
 #' @export
 setMethod("get_exprs", signature(object = "SCESet"),
-          function(object, exprs_values = "exprs") {
-              get_exprs.SCESet(object, exprs_values)
+          function(object, exprs_values = "exprs", warning = TRUE) {
+              get_exprs.SCESet(object, exprs_values, warning = warning)
           })
 
 

--- a/R/SCESet-methods.R
+++ b/R/SCESet-methods.R
@@ -604,6 +604,9 @@ setReplaceMethod("pData", signature(object = "SCESet", value = "data.frame"),
 #' expression values) or \code{"stand_exprs"} (standardised expression values)
 #' or any other slots that have been added to the \code{"assayData"} slot by
 #' the user.
+#' @param warning a logical scalar specifying whether a warning should be 
+#' raised, and \code{NULL} returned, if the requested expression values are 
+#' not present in \code{object}. Otherwise, an error will be thrown.
 #' @author Davis McCarthy
 #' @export
 #' @examples
@@ -617,10 +620,18 @@ setReplaceMethod("pData", signature(object = "SCESet", value = "data.frame"),
 #' colSums(counts(example_sceset)))
 #' get_exprs(example_sceset, "scaled_counts")[1:6, 1:6]
 #'
-get_exprs.SCESet <- function(object, exprs_values = "exprs") {
+get_exprs.SCESet <- function(object, exprs_values = "exprs", warning=TRUE) {
     exprs_mat <- object@assayData[[exprs_values]]
-    if ( is.null(exprs_mat) )
-        warning(paste0("The object does not contain ", exprs_values, " expression values. Returning NULL."))
+
+    if ( is.null(exprs_mat) ) {
+        msg <- sprintf("'object' does not contain '%s'", exprs_values)
+        if (warning) {
+            warning(paste0(msg, ", returning NULL"))
+        } else {
+            stop(msg)
+        }
+    }
+
     exprs_mat
 }
 

--- a/R/SCESet-methods.R
+++ b/R/SCESet-methods.R
@@ -1788,6 +1788,57 @@ setReplaceMethod("featDist", signature(object = "SCESet", value = "dist"),
 
 
 ################################################################################
+### featureControlInfo
+
+#' featureControlInfo in an SCESet object
+#'
+#' Each SCESet object stores optional information about the controls in the 
+#' \code{featureControlInfo} slot. These functions can be used to access,
+#' replace or modify this information.
+#'
+#' @param object a \code{SCESet} object.
+#' @param value an AnnotatedDataFrame object, where each row contains 
+#' information for a single set of control features.
+#'
+#' @docType methods
+#' @name featureControlInfo
+#' @rdname featureControlInfo
+#' @aliases featureControlInfo featureControlInfo,SCESet-method featureControlInfo<-,SCESet,AnnotatedDataFrame-method featureControlInfo<- 
+#'
+#' @author Aaron Lun 
+#'
+#' @return An SCESet object containing new feature control information.
+#' @export
+#' @examples
+#' data("sc_example_counts")
+#' data("sc_example_cell_info")
+#' pd <- new("AnnotatedDataFrame", data = sc_example_cell_info)
+#' example_sceset <- newSCESet(countData = sc_example_counts, phenoData = pd)
+#' example_sceset <- calculateQCMetrics(example_sceset, feature_controls = list(ERCC = 1:40, Mito=41:50))
+#' featureControlInfo(example_sceset) 
+#' featureControlInfo(example_sceset)$IsSpike <- c(TRUE, FALSE)
+featureControlInfo.SCESet <- function(object) {
+    object@featureControlInfo
+}
+
+#' @rdname featureControlInfo
+#' @aliases featureControlInfo
+#' @export
+setMethod("featureControlInfo", signature(object = "SCESet"),
+          featureControlInfo.SCESet)
+
+#' @name featureControlInfo<-
+#' @aliases featureControlInfo
+#' @rdname featureControlInfo
+#' @export "featureControlInfo<-"
+setReplaceMethod("featureControlInfo", signature(object = "SCESet",
+                                                 value = "AnnotatedDataFrame"),
+                 function(object, value) {
+                     object@featureControlInfo <- value
+                     return(object)
+                 })
+
+################################################################################
 ### Convert to and from Monocle CellDataSet objects
 
 #' Convert an \code{SCESet} to a \code{CellDataSet}

--- a/R/calculate-expression.R
+++ b/R/calculate-expression.R
@@ -21,12 +21,13 @@
 #' example_sceset <- newSCESet(countData=sc_example_counts)
 #' is_exprs(example_sceset) <- calcIsExprs(example_sceset, lowerDetectionLimit = 1,
 #' exprs_data = "exprs")
-calcIsExprs <- function(object, lowerDetectionLimit = NULL, exprs_data = "counts")
+calcIsExprs <- function(object, lowerDetectionLimit = NULL, exprs_data = NULL)
 {
     if ( !is(object, "SCESet") )
         stop("Object must be an SCESet.")
+    
     ## Check that args are appropriate
-    exprs_data <- match.arg(exprs_data, c("counts", "exprs", "tpm", "cpm", "fpkm"))
+    exprs_data <- .exprs_hunter(object, exprs_data)
     dat_matrix <- switch(exprs_data,
                          counts = counts(object),
                          exprs = exprs(object),
@@ -36,6 +37,7 @@ calcIsExprs <- function(object, lowerDetectionLimit = NULL, exprs_data = "counts
     if ( is.null(dat_matrix) )
         stop(paste0("Tried to use ", exprs_data, " as expression data, but ", 
                     exprs_data, "(object) is null."))
+
     #     
     #     if ( exprs_data == "counts" ) {
     #         dat_matrix <- counts(object)
@@ -46,9 +48,11 @@ calcIsExprs <- function(object, lowerDetectionLimit = NULL, exprs_data = "counts
     #         else
     #             
     #     }
+
     ## Extract lowerDetectionLimit if not provided
     if ( is.null(lowerDetectionLimit) )
         lowerDetectionLimit <- object@lowerDetectionLimit
+
     ## Decide which observations are above detection limit and return matrix
     isexprs <- dat_matrix > lowerDetectionLimit
     rownames(isexprs) <- rownames(dat_matrix)
@@ -96,7 +100,8 @@ nexprs <- function(object, lowerDetectionLimit = NULL, exprs_data = "counts", su
         stop("'object' must be a SCESet")
     }
     is_exprs_mat <- is_exprs(object)
-    exprs_data <- match.arg(exprs_data, c("counts", "exprs", "tpm", "cpm", "fpkm"))
+
+    exprs_data <- .exprs_hunter(object, exprs_data)
     exprs_mat <- switch(exprs_data,
                         counts = counts(object),
                         exprs = exprs(object),

--- a/R/calculate-expression.R
+++ b/R/calculate-expression.R
@@ -291,6 +291,7 @@ calculateFPKM <- function(object, effective_length, use.size.factors=TRUE) {
     if ( !is(object, "SCESet"))
         stop("object must be an SCESet")
     cpms <- calculateCPM(object, use.size.factors=use.size.factors)
+    effective_length <- effective_length/1e3
     cpms/effective_length
 }
 

--- a/R/calculate-expression.R
+++ b/R/calculate-expression.R
@@ -11,7 +11,8 @@
 #' (\code{"counts"}), the transformed expression data (\code{"exprs"}), 
 #' transcript-per-million (\code{"tpm"}), counts-per-million (\code{"cpm"}) or 
 #' FPKM (\code{"fpkm"}) should be used to define if an observation is expressed 
-#' or not.
+#' or not. Defaults to the first available value of those options in the
+#' order shown.
 #' @return a logical matrix indicating whether or not a feature in a particular 
 #' cell is expressed.
 #' @export
@@ -51,8 +52,9 @@ calcIsExprs <- function(object, lowerDetectionLimit = NULL, exprs_data = NULL)
 #' (\code{"counts"}), the transformed expression data (\code{"exprs"}), 
 #' transcript-per-million (\code{"tpm"}), counts-per-million (\code{"cpm"}) or 
 #' FPKM (\code{"fpkm"}) should be used to define if an observation is expressed 
-#' or not. However, if \code{is_exprs(object)} is present, it will be used directly 
-#' such that \code{exprs_data} and \code{lowerDetectionLimit} are ignored.
+#' or not. Defaults to the first available value of those options in the
+#' order shown. However, if \code{is_exprs(object)} is present, it will be 
+#' used directly; \code{exprs_data} and \code{lowerDetectionLimit} are ignored.
 #' @param subset.row logical or character vector indicating which rows 
 #' (i.e. features/genes) to subset and calculate 'is_exprs_mat' for.
 #' @param byrow logical scalar indicating if \code{TRUE} to count expressing 
@@ -76,7 +78,7 @@ calcIsExprs <- function(object, lowerDetectionLimit = NULL, exprs_data = NULL)
 #' nexprs(example_sceset)[1:10]
 #' nexprs(example_sceset, byrow = TRUE)[1:10]
 #' 
-nexprs <- function(object, lowerDetectionLimit = NULL, exprs_data = "counts", subset.row = NULL, byrow = FALSE) {
+nexprs <- function(object, lowerDetectionLimit = NULL, exprs_data = NULL, subset.row = NULL, byrow = FALSE) {
     if (!is(object, "SCESet")) { 
         stop("'object' must be a SCESet")
     }

--- a/R/normalisation.R
+++ b/R/normalisation.R
@@ -325,14 +325,6 @@ normalize.SCESet <- function(object, exprs_values = NULL,
     return(object)
 }
 
-.recompute_cpm_fun <- function(exprs_mat, size_factors,
-                               lib_size, logExprsOffset) {
-    edgeR::cpm.default(exprs_mat,
-       # centering size factors on the average library size:
-       lib.size = (size_factors * mean(lib_size) / mean(size_factors)),
-       log = FALSE, prior.count = logExprsOffset)
-}
-
 .recompute_expr_fun <- function(exprs_mat, size_factors, logExprsOffset, 
                                 subset.row = NULL) {
     .compute_exprs(exprs_mat, size_factors,

--- a/R/normalisation.R
+++ b/R/normalisation.R
@@ -8,7 +8,7 @@
 #' object with the normalised expression values added.
 #'
 #' @param object an \code{SCESet} object.
-#' @param method character string giving method to be used to calculate
+#' @param method character string specified the method of calculating 
 #' normalisation factors. Passed to \code{\link[edgeR]{calcNormFactors}}.
 #' @param design design matrix defining the linear model to be fitted to the
 #' normalised expression values. If not \code{NULL}, then the residuals of this
@@ -19,10 +19,10 @@
 #' be indices for features. If logical, vector is used to index features and should 
 #' have length equal to \code{nrow(object)}.
 #' @param exprs_values character string indicating which slot of the
-#' assayData from the \code{SCESet} object should be used as expression values.
-#' Valid options are \code{'counts'}, the count values, \code{'exprs'} the
-#' expression slot, \code{'tpm'} the transcripts-per-million slot or
-#' \code{'fpkm'} the FPKM slot.
+#' assayData from the \code{SCESet} object should be used for the calculations.
+#' Valid options are \code{'counts'}, \code{'tpm'}, \code{'cpm'}, \code{'fpkm'}
+#' and \code{'exprs'}. Defaults to the first available value of these options in 
+#' in order shown.
 #' @param return_norm_as_exprs logical, should the normalised expression values
 #' be returned to the \code{exprs} slot of the object? Default is TRUE. If
 #' FALSE, values in the \code{exprs} slot will be left untouched. Regardless,
@@ -33,25 +33,20 @@
 #'
 #' @details This function allows the user to compute normalised expression
 #' values from an SCESet object. The 'raw' values used can be the values in the
-#' \code{'counts'} (default), \code{'exprs'}, \code{'tpm'} or \code{'fpkm'} slot
-#' of the SCESet. Normalised expression values are added to the
-#' \code{'norm_exprs'} slot of the object. Normalised expression values are on
-#' the log2-scale, with an offset defined by the \code{logExprsOffset}
-#' slot of the SCESet object. If the \code{'exprs_values'} argument is one of
-#' \code{'counts'}, \code{'tpm'} or \code{'fpkm'}, then a corresponding slot
-#' with normalised values is added: \code{'norm_counts'},
-#' \code{'norm_tpm'} or \code{'norm_fpkm'}, as appropriate. If
-#' \code{'exprs_values'} argument is \code{'counts'} a \code{'norm_cpm'} slot is
-#' also added, containing normalised counts-per-million values.
+#' \code{'counts'} (default), \code{'tpm'}, \code{'cpm'} or \code{'fpkm'} slot
+#' of the SCESet. Normalised expression values are computed through
+#' \code{\link{normalize.SCESet}} and are on the log2-scale, with an offset 
+#' defined by the \code{logExprsOffset} slot of the SCESet object. These are
+#' dded to the \code{'norm_exprs'} slot of the returned object. If 
+#' \code{'exprs_values'} argument is \code{'counts'}, a \code{'norm_cpm'} slot 
+#' is also added, containing normalised counts-per-million values.
 #'
-#' Normalisation is done relative to a defined feature set, if desired, which
-#' defines the 'library size' by which expression values are divided. If no
-#' feature set is defined, then all features are used. A normalisation size
-#' factor can be computed (optionally), which internally uses
-#' \code{\link[edgeR]{calcNormFactors}}. Thus, any of the methods available for
-#' \code{\link[edgeR]{calcNormFactors}} can be used: "TMM", "RLE", "upperquartile"
-#' or "none". See that function for further details. Library sizes are multiplied
-#' by size factors to obtain a "normalised library size" before normalisation.
+#' If the raw values are counts, this function will compute size factors using
+#' methods in \code{\link[edgeR]{calcNormFactors}}. Library sizes are multiplied
+#' by size factors to obtain an "effective library size" before calculation of 
+#' the aforementioned normalized expression values. If \code{feature_set} is 
+#' specified, only the specified features will be used to calculate the 
+#' size factors.
 #'
 #' If the user wishes to remove the effects of certain explanatory variables,
 #' then the \code{'design'} argument can be defined. The \code{design} argument
@@ -59,7 +54,7 @@
 #' \code{\link[stats]{model.matrix}}, with the relevant variables. A linear
 #' model is then fitted using \code{\link[limma]{lmFit}} on expression values
 #' after any size-factor and library size normalisation as descrived above. The
-#' returned normalised expression values are then the residuals from the linear
+#' returned values in \code{'norm_exprs'} are the residuals from the linear
 #' model fit.
 #'
 #' After normalisation, normalised expression values can be accessed with the
@@ -180,10 +175,10 @@ normalizeExprs <- function(...) {
 #'
 #' @param object an \code{SCESet} object.
 #' @param exprs_values character string indicating which slot of the
-#' assayData from the \code{SCESet} object should be used as expression values.
-#' Valid options are \code{'counts'}, the count values, \code{'exprs'} the
-#' expression slot, \code{'tpm'} the transcripts-per-million slot or
-#' \code{'fpkm'} the FPKM slot.
+#' assayData from the \code{SCESet} object should be used to compute 
+#' log-transformed expression values. Valid options are \code{'counts'}, 
+#' \code{'tpm'}, \code{'cpm'} and \code{'fpkm'}. Defaults to the first
+#' available value of the options in the order shown.
 #' @param logExprsOffset scalar numeric value giving the offset to add when
 #' taking log2 of normalised values to return as expression values. If NULL
 #' (default), then the value from \code{object@logExprsOffset} is used.

--- a/R/normalisation.R
+++ b/R/normalisation.R
@@ -233,10 +233,12 @@ normalize.SCESet <- function(object, exprs_values = NULL,
     exprs_mat <- get_exprs(object, exprs_values, warning=FALSE)
 
     ## extract existing size factors
-    size_factors <- sizeFactors(object)
-    if ( is.null(size_factors) && exprs_values=="counts") {
-        warning("skipping normalization of counts as size factors were not defined")
-        return(object)
+    if (exprs_values=="counts") {
+        size_factors <- suppressWarnings(sizeFactors(object))
+        if ( is.null(size_factors) ) {
+            warning("skipping normalization of counts as size factors were not defined")
+            return(object)
+        }
     } else {
         size_factors <- rep(1, ncol(object)) # ignoring size factors for non-count data.
     }

--- a/R/qc.R
+++ b/R/qc.R
@@ -176,13 +176,6 @@ calculateQCMetrics <- function(object, feature_controls = NULL,
         stop("object must have at least one sample (column)")
     if ( nrow(object) < 1 )
         stop("object must have at least one feature (row)")
-    ## Compute cell-level metrics
-    if ( is.null(is_exprs(object)) ) {
-        if (is.null(counts(object))) {
-            stop("need either is_exprs(object) or counts(object) to be defined,
-  e.g., use `is_exprs(object) <- exprs(object) > 0.1`")
-        }
-    }
 
     ## See what versions of the expression data are available in the object
     exprs_mat <- exprs(object)

--- a/R/test.R
+++ b/R/test.R
@@ -1,0 +1,6 @@
+whee <- function(object){
+    sizeFactors(object)
+}
+
+setMethod("normalize", "SummarizedExperiment", function(object) "whee")
+

--- a/R/utils.R
+++ b/R/utils.R
@@ -58,7 +58,7 @@
 }
 
 ## contains the hierarchy of expression values.
-.exprs_hierarchy <- c("tpm", "counts", "cpm", "fpkm", "exprs")
+.exprs_hierarchy <- c("counts", "tpm", "cpm", "fpkm", "exprs")
 
 .exprs_hunter <- function(object, proposed=NULL) {
     ## Finds the highest ranking expression category that is not NULL.

--- a/R/utils.R
+++ b/R/utils.R
@@ -57,3 +57,21 @@
                  as.logical(sum), subset.row - 1L)
 }
 
+## contains the hierarchy of expression values.
+.exprs_hierarchy <- c("tpm", "counts", "cpm", "fpkm", "exprs")
+
+.exprs_hunter <- function(object, proposed=NULL) {
+    ## Finds the highest ranking expression category that is not NULL.
+    if (!is.null(proposed)) { 
+        proposed <- match.arg(proposed, .exprs_hierarchy)
+    } else {
+        m <- match(.exprs_hierarchy, assayDataElementNames(object))
+        failed <- is.na(m)
+        if (all(failed)) {
+            stop("no expression values present in 'object'")
+        }
+        proposed <- assayDataElementNames(object)[m[!failed][1]]
+    }
+    return(proposed)
+}
+


### PR DESCRIPTION
- Added `calculateCPM` to respect size factors during the CPM calculation.
- `normalize` now _only_ recomputes `exprs`, and tries to do nothing else.
- `nexprs` and `calcIsExprs` will "hunt" for an appropriate value to use, if not specified.
