### PR TITLE
Winding back C++

### DIFF
--- a/R/SCESet-methods.R
+++ b/R/SCESet-methods.R
@@ -281,12 +281,16 @@ setValidity("SCESet", function(object) {
         msg <- c(msg,
                  "Label names of featurePairwiseDistances must be identical to featureNames(SCESet)")
     }
-    ## Check that we have sensible values for the counts
-    if( .checkedCall(cxx_missing_exprs, exprs(object)) ) {
-        warning( "'exprs' contains missing values" )
-    }
-    if ( (!is.null(counts(object))) && .checkedCall(cxx_negative_counts, counts(object)) )
-        warning( "'counts' contains negative values" )
+
+## AL: People can put whatever they like, but it's their responsibility if they put in stupid things.
+## Some functions will care about NAs, others will not.
+#    ## Check that we have sensible values for the counts
+#    if (any(is.na(exprs(object)))) { 
+#        warning( "'exprs' contains missing values" )
+#    }
+#    if (!is.null(counts(object)) && any(counts(object) < 0)) {
+#        warning( "'counts' contains negative values" )
+#    }
 
     if (valid) TRUE else msg
 })

--- a/R/SCESet-methods.R
+++ b/R/SCESet-methods.R
@@ -123,16 +123,6 @@ newSCESet <- function(exprsData = NULL,
         stop("one set of expression values should be supplied")
     }
 
-    if (!is.null(is_exprsData)) {
-        if (have.data != "exprsData") {
-            warning(sprintf("'%s' provided, 'is_exprsData' will be ignored",
-                            have.data))
-            is_exprsData <- NULL
-        } else {
-            is_exprsData <- as.matrix(is_exprsData)
-        }
-    }
-
     ## Setting logExprsOffset and lowerDetectionLimit.
     if (is.null(logExprsOffset)) {
         logExprsOffset <- 1
@@ -156,6 +146,19 @@ newSCESet <- function(exprsData = NULL,
         dimnames(exprsData) <- dimnames(countData)
     } else if (have.data != "exprsData") {
         exprsData <- log2(get(have.data) + logExprsOffset)
+    }
+
+    ## If no is_exprsData provided, define it from exprsData.
+    if (!is.null(is_exprsData)) {
+        if (have.data != "exprsData") {
+            warning(sprintf("'%s' provided, 'is_exprsData' will be ignored",
+                            have.data))
+            is_exprsData <- NULL
+        } else {
+            is_exprsData <- as.matrix(is_exprsData)
+        }
+    } else {
+        is_exprsData <- exprsData > lowerDetectionLimit
     }
 
     ## Generate valid phenoData and featureData if not provided

--- a/R/calculate-expression.R
+++ b/R/calculate-expression.R
@@ -107,14 +107,14 @@ nexprs <- function(object, lowerDetectionLimit = NULL, exprs_values = NULL, byro
         if (is.null(subset_row)) {
             out <- colSums(is_exprs_mat)
         } else {
-            out <- colSums(is_exprs_mat[subset.row,,drop=FALSE])
+            out <- colSums(is_exprs_mat[subset_row,,drop=FALSE])
         }
     } else {
         # Counting expressing cells per gene.
         if (is.null(subset_col)) { 
             out <- rowSums(is_exprs_mat)
         } else {
-            out <- rowSums(is_exprs_mat[,subset.col,drop=FALSE])
+            out <- rowSums(is_exprs_mat[,subset_col,drop=FALSE])
         }
     }
     return(out)

--- a/R/calculate-expression.R
+++ b/R/calculate-expression.R
@@ -95,7 +95,7 @@ nexprs <- function(object, lowerDetectionLimit = NULL, exprs_values = NULL, byro
     }
 
     # Building the expression profile.
-    if (!is.null(is_exprs_mat)) {
+    if (is.null(is_exprs_mat)) {
         if (is.null(lowerDetectionLimit)) {
             lowerDetectionLimit <- object@lowerDetectionLimit
         }

--- a/R/qc.R
+++ b/R/qc.R
@@ -391,9 +391,8 @@ calculateQCMetrics <- function(object, feature_controls = NULL,
     if (is.logical(is_feature_control)) { 
         is_feature_control <- which(is_feature_control) 
     }
-    exprs_feature_controls <- .checkedCall(cxx_colsum_subset, exprs_mat, 
-                                           is_feature_control - 1L) 
-
+    exprs_feature_controls <- colSums(exprs_mat[is_feature_control,,drop=FALSE])
+   
     ## Get % expression from feature controls
     pct_exprs_feature_controls <- (100 * exprs_feature_controls /
                                          colSums(exprs_mat))


### PR DESCRIPTION
I think we may have gone a bit crazy with converting things to C++. The idea was to save memory, but this will become less of an issue with _HDF5Array_ becoming available. Thus, I've wound back the uses of the trivial C++ equivalents to `colSums` and `rowSums`. 

In addition, `is_exprs` is now directly defined in the constructor. Validity checks for missing values and negative counts have been removed, as these may or may not be expected. For example, missing values may be expected in allele-specific expression studies where no SNPs are available.