### PR TITLE
Switched from 'exprs' to 'logcounts' internally.

### DIFF
--- a/R/SingleCellExperiment-methods.R
+++ b/R/SingleCellExperiment-methods.R
@@ -4,9 +4,9 @@
 ################################################################################
 ### counts
 
-#' Accessors for the typical elements of a SingleCellExperiment object.
+#' Additional accessors for the typical elements of a SingleCellExperiment object.
 #'
-#' Convenience function to access commonly-used assays (counts, exprs, etc) of the 
+#' Convenience functions to access commonly-used assays of the 
 #' \code{\link{SingleCellExperiment}} object.
 #' 
 #' @param exprs_values character(1), type of expression values for which 
@@ -75,11 +75,13 @@ SET_FUN <- function(exprs_values) {
     }
 }
 
-for (x in c("norm_exprs", "stand_exprs", "tpm", "cpm", "fpkm",  
-            "counts", "normcounts", "logcounts", "exprs")) { 
+for (x in c("norm_exprs", "stand_exprs", "fpkm")) { 
     setMethod(x, "SingleCellExperiment", GET_FUN(x))
     setReplaceMethod(x, c("SingleCellExperiment", "ANY"), SET_FUN(x))
 }
+
+setMethod("exprs", "SingleCellExperiment", GET_FUN("logcounts"))
+setReplaceMethod("exprs", c("SingleCellExperiment", "ANY"), SET_FUN("logcounts"))
 
 ################################################################################
 ### bootstraps

--- a/R/calculate-expression.R
+++ b/R/calculate-expression.R
@@ -9,7 +9,7 @@
 #' @param lowerDetectionLimit numeric scalar giving the minimum expression level
 #' for an expression observation in a cell for it to qualify as expressed.
 #' @param exprs_values character scalar indicating whether the count data
-#' (\code{"counts"}), the transformed expression data (\code{"exprs"}),
+#' (\code{"counts"}), the log-transformed count data (\code{"logcounts"}),
 #' transcript-per-million (\code{"tpm"}), counts-per-million (\code{"cpm"}) or
 #' FPKM (\code{"fpkm"}) should be used to define if an observation is expressed
 #' or not. Defaults to the first available value of those options in the
@@ -37,7 +37,7 @@ calcIsExprs <- function(object, lowerDetectionLimit = 0,
 #' observations are deemed to be expressed. Defaults to 
 #' \code{object@lowerDetectionLimit}.
 #' @param exprs_values character scalar indicating whether the count data
-#' (\code{"counts"}), the transformed expression data (\code{"exprs"}),
+#' (\code{"counts"}), the log-transformed count data (\code{"logcounts"}),
 #' transcript-per-million (\code{"tpm"}), counts-per-million (\code{"cpm"}) or
 #' FPKM (\code{"fpkm"}) should be used to define if an observation is expressed
 #' or not. Defaults to the first available value of those options in the

--- a/R/gui.R
+++ b/R/gui.R
@@ -90,7 +90,7 @@ scater_gui <- function(object) {
                                                    selected = pd.plot[4]),
                                        selectInput("exprs_values", "exprs_values:",
                                                    exprs_values,
-                                                   selected = "exprs")
+                                                   selected = "logcounts")
                                 )
                             )
                     ),
@@ -217,7 +217,7 @@ scater_gui <- function(object) {
                                        selectInput("pca_exprs_values",
                                                    "exprs_values:",
                                                    exprs_values, 
-                                                   selected = "exprs"),
+                                                   selected = "logcounts"),
                                        numericInput("pca_ntop",
                                                     "number of most variable features to use:",
                                                     500,
@@ -261,7 +261,7 @@ scater_gui <- function(object) {
                                        selectInput("tsne_exprs_values",
                                                    "exprs_values:",
                                                    exprs_values, 
-                                                   selected = "exprs"),
+                                                   selected = "logcounts"),
                                        numericInput("tsne_ntop",
                                                     "number of most variable features to use:",
                                                     500,
@@ -308,7 +308,7 @@ scater_gui <- function(object) {
                                        selectInput("diffmap_exprs_values",
                                                    "exprs_values:",
                                                    exprs_values, 
-                                                   selected = "exprs"),
+                                                   selected = "logcounts"),
                                        numericInput("diffmap_ntop",
                                                     "number of most variable features to use:",
                                                     500,
@@ -373,7 +373,7 @@ scater_gui <- function(object) {
                                        selectInput("exprs_exprs_values",
                                                    "exprs_values:",
                                                    exprs_values, 
-                                                   selected = "exprs"),
+                                                   selected = "logcounts"),
                                        numericInput("exprs_ncols",
                                                     "number of columns:",
                                                     2, min = 1, max = 8),

--- a/R/magic.R
+++ b/R/magic.R
@@ -22,8 +22,8 @@
 # #' values), \code{"fpkm"} (FPKM values), \code{"norm_fpkm"} (normalised FPKM
 # #' values), \code{"counts"} (counts for each feature), \code{"norm_counts"},
 # #' \code{"cpm"} (counts-per-million), \code{"norm_cpm"} (normalised
-# #' counts-per-million), \code{"exprs"} (whatever is in the \code{'exprs'} slot
-# #' of the \code{SCESet} object; default), \code{"norm_exprs"} (normalised
+# #' counts-per-million), \code{"logcounts"} (log-transformed count data;
+# #' default), \code{"norm_exprs"} (normalised
 # #' expression values) or \code{"stand_exprs"} (standardised expression values)
 # #' or any other slots that have been added to the \code{"assayData"} slot by
 # #' the user.
@@ -72,7 +72,7 @@
 # #' example_sceset <- example_sceset[rowSums(counts(example_sceset)) > 0.5, ]
 # #' mgc <- magic(example_sceset, power = 6, k = 30, n_eigs = 20, n_local = 10)
 # #'
-magic <- function(x, power = 6L, rescale = NULL, exprs_values="exprs", logged_data = TRUE, ...) {
+magic <- function(x, power = 6L, rescale = NULL, exprs_values="logcounts", logged_data = TRUE, ...) {
     if (is(x, "SingleCellExperiment")) {
         exprs_mat <- assay(x, i=exprs_values)
     } else {

--- a/R/plotting.R
+++ b/R/plotting.R
@@ -91,7 +91,7 @@
 .choose_vis_values <- function(x, by, check_coldata = TRUE,
                                cell_control_default = FALSE,
                                check_features = FALSE,
-                               exprs_values = "exprs",
+                               exprs_values = "logcounts",
                                coerce_factor = FALSE, level_limit = NA) {
     ## This function looks through the visualization data and returns the
     ## values to be visualized. Either 'by' itself, or a column of colData,
@@ -264,13 +264,13 @@ plotScater <- function(x, block1 = NULL, block2 = NULL, colour_by = NULL,
     nfeatures_to_plot <- nfeatures
     to_plot <- seq_len(nfeatures_to_plot)
     seq_real_estate_long <- reshape2::melt(seq_real_estate[to_plot, ],
-                                           value.name = "exprs")
+                                           value.name = exprs_values)
 
     ## Get the proportion of the library accounted for by the top features
     prop_library <- reshape2::melt(t(t(seq_real_estate[to_plot, ]) /
                                          colSums(exprs_mat)),
                                    value.name = "prop_library")
-    colnames(seq_real_estate_long) <- c("Feature", "Cell", "exprs")
+    colnames(seq_real_estate_long) <- c("Feature", "Cell", exprs_values)
     seq_real_estate_long$Proportion_Library <- prop_library$prop_library
 
     ## Add block and colour_by information if provided
@@ -344,8 +344,8 @@ plotScater <- function(x, block1 = NULL, block2 = NULL, colour_by = NULL,
 #' values), \code{"fpkm"} (FPKM values), \code{"norm_fpkm"} (normalised FPKM
 #' values), \code{"counts"} (counts for each feature), \code{"norm_counts"},
 #' \code{"cpm"} (counts-per-million), \code{"norm_cpm"} (normalised
-#' counts-per-million), \code{"exprs"} (whatever is in the \code{'exprs'} slot
-#' of the \code{SingleCellExperiment} object; default), \code{"norm_exprs"} (normalised
+#' counts-per-million), \code{"logcounts"} (log-transformed count data; default),
+#' \code{"norm_exprs"} (normalised
 #' expression values) or \code{"stand_exprs"} (standardised expression values)
 #' or any other named element of the \code{assays} slot of the \code{SingleCellExperiment}
 #' object that can be accessed with the \code{assay} function.
@@ -357,8 +357,8 @@ plotScater <- function(x, block1 = NULL, block2 = NULL, colour_by = NULL,
 #' @param scale_features logical, should the expression values be standardised
 #' so that each feature has unit variance? Default is \code{TRUE}.
 #' @param pca_data_input character argument defining which data should be used
-#' as input for the PCA. Possible options are \code{"exprs"} (default), which
-#' uses expression data to produce a PCA at the cell level; \code{"coldata"} or
+#' as input for the PCA. Possible options are \code{"logcounts"} (default), which
+#' uses log-count data to produce a PCA at the cell level; \code{"coldata"} or
 #' \code{"pdata"} (for backwards compatibility) which uses numeric variables
 #' from \code{colData(object)} to do PCA at the cell level; and
 #' \code{"rowdata"} which uses numeric variables from \code{rowData(object)} to
@@ -372,8 +372,8 @@ plotScater <- function(x, block1 = NULL, block2 = NULL, colour_by = NULL,
 #'
 #' @rdname plotPCA
 #' @export
-runPCA <- function(object, ntop=500, ncomponents=2, exprs_values = "exprs",
-       feature_set = NULL, scale_features = TRUE, pca_data_input = "exprs",
+runPCA <- function(object, ntop=500, ncomponents=2, logcounts_values = "logcounts",
+       feature_set = NULL, scale_features = TRUE, pca_data_input = "logcounts",
        selected_variables = NULL, detect_outliers = FALSE) {
 
     exprs_mat <- assay(object, i = exprs_values)
@@ -606,8 +606,8 @@ setMethod("plotPCA", "SingleCellExperiment", plotPCASCE)
 #' values), \code{"fpkm"} (FPKM values), \code{"norm_fpkm"} (normalised FPKM
 #' values), \code{"counts"} (counts for each feature), \code{"norm_counts"},
 #' \code{"cpm"} (counts-per-million), \code{"norm_cpm"} (normalised
-#' counts-per-million), \code{"exprs"} (whatever is in the \code{'exprs'} slot
-#' of the \code{SingleCellExperiment} object; default), \code{"norm_exprs"} (normalised
+#' counts-per-million), \code{"logcounts"} (log-transformed count data; default),
+#' \code{"norm_exprs"} (normalised
 #' expression values) or \code{"stand_exprs"} (standardised expression values),
 #' or any other named element of the \code{assayData} slot of the \code{SingleCellExperiment}
 #' object that can be accessed with the \code{assay} function.
@@ -632,7 +632,7 @@ setMethod("plotPCA", "SingleCellExperiment", plotPCASCE)
 #'
 #' @rdname plotTSNE
 #' @export
-runTSNE <- function(object, ntop = 500, ncomponents = 2, exprs_values = "exprs",
+runTSNE <- function(object, ntop = 500, ncomponents = 2, exprs_values = "logcounts",
         feature_set = NULL, use_dimred = NULL, n_dimred = NULL, scale_features = TRUE,
         rand_seed = NULL, perplexity = floor(ncol(object) / 5), ...) {
 
@@ -800,8 +800,8 @@ plotTSNE <- function(object, colour_by = NULL, shape_by = NULL, size_by = NULL,
 #' values), \code{"fpkm"} (FPKM values), \code{"norm_fpkm"} (normalised FPKM
 #' values), \code{"counts"} (counts for each feature), \code{"norm_counts"},
 #' \code{"cpm"} (counts-per-million), \code{"norm_cpm"} (normalised
-#' counts-per-million), \code{"exprs"} (whatever is in the \code{'exprs'} slot
-#' of the \code{SingleCellExperiment} object; default), \code{"norm_exprs"} (normalised
+#' counts-per-million), \code{"logcounts"} (log-transformed count data; default),
+#' \code{"norm_exprs"} (normalised
 #' expression values) or \code{"stand_exprs"} (standardised expression values)
 #' or any other named element of the \code{assayData} slot of the \code{SingleCellExperiment}
 #' object that can be accessed with the \code{assay} function.
@@ -826,7 +826,7 @@ plotTSNE <- function(object, colour_by = NULL, shape_by = NULL, size_by = NULL,
 #' @export
 #' @rdname plotDiffusionMap
 runDiffusionMap <- function(object, ntop = 500, ncomponents = 2, feature_set = NULL,
-        exprs_values = "exprs", scale_features = TRUE, use_dimred=NULL, n_dimred=NULL,
+        exprs_values = "logcounts", scale_features = TRUE, use_dimred=NULL, n_dimred=NULL,
         rand_seed = NULL, sigma = NULL, distance = "euclidean", ...) {
 
     if (!is.null(use_dimred)) {
@@ -973,7 +973,7 @@ plotDiffusionMap <- function(object, colour_by = NULL, shape_by = NULL, size_by 
 ### plotMDS
 
 runMDS <- function(object, ntop = 500, ncomponents = 2, feature_set = NULL,
-        exprs_values = "exprs", scale_features = TRUE, use_dimred=NULL, n_dimred=NULL,
+        exprs_values = "logcounts", scale_features = TRUE, use_dimred=NULL, n_dimred=NULL,
         method = "euclidean") {
 
     if (!is.null(use_dimred)) {
@@ -1083,7 +1083,7 @@ runMDS <- function(object, ntop = 500, ncomponents = 2, feature_set = NULL,
 #'
 plotMDS <- function(object, ncomponents = 2, colour_by = NULL,
                     shape_by = NULL, size_by = NULL, return_SCE = FALSE,
-                    rerun = FALSE, draw_plot = TRUE, exprs_values = "exprs",
+                    rerun = FALSE, draw_plot = TRUE, exprs_values = "logcounts",
                     theme_size = 10, legend = "auto", ...) {
 
     if ( !("MDS" %in% names(reducedDims(object))) || rerun) {
@@ -1318,7 +1318,7 @@ plotReducedDimDefault <- function(df_to_plot, ncomponents=2, percentVar=NULL,
 #' @export
 plotReducedDim <- function(object, use_dimred, ncomponents = 2,
                               colour_by = NULL, shape_by = NULL, size_by = NULL,
-                              exprs_values = "exprs", percentVar = NULL, ...) {
+                              exprs_values = "logcounts", percentVar = NULL, ...) {
 
     ## Check arguments are valid
     colour_by_out <- .choose_vis_values(
@@ -1424,7 +1424,7 @@ plotReducedDim <- function(object, use_dimred, ncomponents = 2,
 plotPlatePosition <- function(object, plate_position = NULL,
                               colour_by = NULL,
                               x_position = NULL, y_position = NULL,
-                              exprs_values = "exprs", theme_size = 24, legend = "auto") {
+                              exprs_values = "logcounts", theme_size = 24, legend = "auto") {
     ## check object is SingleCellExperiment object
     if ( !is(object, "SingleCellExperiment") )
         stop("Object must be of class SingleCellExperiment")
@@ -1517,8 +1517,8 @@ plotPlatePosition <- function(object, plate_position = NULL,
 #' values), \code{"fpkm"} (FPKM values), \code{"norm_fpkm"} (normalised FPKM
 #' values), \code{"counts"} (counts for each feature), \code{"norm_counts"},
 #' \code{"cpm"} (counts-per-million), \code{"norm_cpm"} (normalised
-#' counts-per-million), \code{"exprs"} (whatever is in the \code{'exprs'} slot
-#' of the \code{SingleCellExperiment} object; default), \code{"norm_exprs"} (normalised
+#' counts-per-million), \code{"logcounts"} (log-transformed count data; default),
+#' \code{"norm_exprs"} (normalised
 #' expression values) or \code{"stand_exprs"} (standardised expression values)
 #' or any other slots that have been added to the \code{"assayData"} slot by
 #' the user.
@@ -1596,7 +1596,7 @@ plotPlatePosition <- function(object, plate_position = NULL,
 #' plotExpression(example_sce, 1:6, "Mutation_Status")
 #'
 #' ## explore options
-#' plotExpression(example_sce, 1:6, x = "Mutation_Status", exprs_values = "exprs",
+#' plotExpression(example_sce, 1:6, x = "Mutation_Status", exprs_values = "logcounts",
 #' colour_by = "Cell_Cycle", show_violin = TRUE, show_median = TRUE)
 #' plotExpression(example_sce, 1:6, x = "Mutation_Status", exprs_values = "counts",
 #' colour_by = "Cell_Cycle", show_violin = TRUE, show_median = TRUE)
@@ -1607,7 +1607,7 @@ plotPlatePosition <- function(object, plate_position = NULL,
 #' plotExpression(example_sce, 1:4, "Gene_0004", show_smooth = TRUE, se = FALSE)
 #'
 plotExpression <- function(object, features, x = NULL,
-                              exprs_values = "exprs", log2_values = FALSE,
+                              exprs_values = "logcounts", log2_values = FALSE,
                               colour_by = NULL, shape_by = NULL, size_by = NULL,
                               ncol = 2, xlab = NULL, show_median = FALSE,
                            show_violin = TRUE, theme_size = 10, ...) {
@@ -2277,8 +2277,8 @@ multiplot <- function(..., plotlist = NULL, cols = 1, layout = NULL) {
 #' values), \code{"fpkm"} (FPKM values), \code{"norm_fpkm"} (normalised FPKM
 #' values), \code{"counts"} (counts for each feature), \code{"norm_counts"},
 #' \code{"cpm"} (counts-per-million), \code{"norm_cpm"} (normalised
-#' counts-per-million), \code{"exprs"} (whatever is in the \code{'exprs'} slot
-#' of the \code{SingleCellExperiment} object; default), \code{"norm_exprs"} (normalised
+#' counts-per-million), \code{"logcounts"} (log-transformed count data; default),
+#' \code{"norm_exprs"} (normalised
 #' expression values) or \code{"stand_exprs"} (standardised expression values)
 #' or any other slots that have been added to the \code{"assays"} slot by
 #' the user.
@@ -2347,7 +2347,7 @@ multiplot <- function(..., plotlist = NULL, cols = 1, layout = NULL) {
 #' plotExprsVsTxLength(example_sce, rnorm(2000, mean = 5000, sd = 500))
 #'
 plotExprsVsTxLength <- function(object, tx_length = "median_feat_eff_len",
-                                exprs_values = "exprs",
+                                exprs_values = "logcounts",
                                 colour_by = NULL, shape_by = NULL,
                                 size_by = NULL, xlab = NULL,
                                 show_exprs_sd = FALSE,

--- a/R/qc.R
+++ b/R/qc.R
@@ -18,7 +18,7 @@
 #' experimental information. Must have been appropriately prepared.
 #' @param exprs_values character(1), indicating slot of the \code{assays} of the \code{object}
 #' should be used to define expression? Valid options are "counts" [default; recommended],
-#' "tpm", "fpkm" and "exprs", or anything else in the object added manually by 
+#' "tpm", "fpkm" and "logcounts", or anything else in the object added manually by 
 #' the user.
 #' @param feature_controls a named list containing one or more vectors 
 #' (character vector of feature names, logical vector, or a numeric vector of
@@ -510,7 +510,7 @@ isOutlier <- function(metric, nmads = 5, type = c("both", "lower", "higher"),
 #' interest.
 #' @param exprs_values which slot of the \code{assayData} in the \code{object}
 #' should be used to define expression? Valid options are "counts",
-#' "tpm", "fpkm" and "exprs" (default), or anything else in the object added manually by 
+#' "tpm", "fpkm" and "logcounts" (default), or anything else in the object added manually by 
 #' the user.
 #' @param ntop numeric scalar indicating the number of most variable features to
 #' use for the PCA. Default is \code{500}, but any \code{ntop} argument is
@@ -546,7 +546,7 @@ isOutlier <- function(metric, nmads = 5, type = c("both", "lower", "higher"),
 #' findImportantPCs(example_sce, variable="total_features")
 #'
 findImportantPCs <- function(object, variable="total_features",
-                             plot_type = "pcs-vs-vars", exprs_values = "exprs",
+                             plot_type = "pcs-vs-vars", exprs_values = "logcounts",
                              ntop = 500, feature_set = NULL, 
                              scale_features = TRUE, theme_size = 10) {
     if ( !is.null(feature_set) && typeof(feature_set) == "character" ) {
@@ -707,7 +707,7 @@ findImportantPCs <- function(object, variable="total_features",
 #' from endogenous rather than synthetic genes.
 #' @param exprs_values which slot of the \code{assayData} in the \code{object}
 #' should be used to define expression? Valid options are "counts" (default),
-#' "tpm", "fpkm" and "exprs".
+#' "tpm", "fpkm" and "logcounts".
 #' @param feature_names_to_plot character scalar indicating which column of the 
 #' featureData slot in the \code{object} is to be used for the feature names 
 #' displayed on the plot. Default is \code{NULL}, in which case 
@@ -765,7 +765,7 @@ plotHighestExprs <- function(object, col_by_variable = "total_features", n = 50,
 
     ## Define expression values to be used
     exprs_values <- match.arg(exprs_values,
-                              c("exprs", "tpm", "cpm", "fpkm", "counts"))
+                              c("logcounts", "tpm", "cpm", "fpkm", "counts"))
     exprs_mat <- assay(object, exprs_values)
     if ( is.null(exprs_mat) && !is.null(counts(object)) ) {
         exprs_mat <- counts(object)
@@ -774,9 +774,9 @@ plotHighestExprs <- function(object, col_by_variable = "total_features", n = 50,
     } else if ( is.null(exprs_mat) ) {
         exprs_mat <- exprs(object)
         message("Using exprs(object) values as expression values.")
-        exprs_values <- "exprs"
+        exprs_values <- "logcounts"
     }
-    if ( exprs_values == "exprs" ) 
+    if ( exprs_values == "logcounts" ) 
         exprs_mat <- 2 ^ exprs_mat - object@logExprsOffset
 
     ## Find the most highly expressed features in this dataset
@@ -792,7 +792,7 @@ plotHighestExprs <- function(object, col_by_variable = "total_features", n = 50,
             message("Using counts to order total expression of features.")
         }
         else {
-            exprs_values <- "exprs"
+            exprs_values <- "logcounts"
             oo <- order(rdata[["rank_exprs"]], decreasing = TRUE)
             message("Using 'exprs' to order total expression of features.")
         }
@@ -913,7 +913,7 @@ plotHighestExprs <- function(object, col_by_variable = "total_features", n = 50,
 #' ordered by the percentage of feature expression variance (as measured by
 #' R-squared in a marginal linear model) explained.
 #' @param exprs_values which slot of the \code{assayData} in the \code{object}
-#' should be used to define expression? Valid options are "exprs" (default),
+#' should be used to define expression? Valid options are "logcounts" (default),
 #' "tpm", "fpkm", "cpm", and "counts".
 #' @param nvars_to_plot integer, the number of variables to plot in the pairs
 #' plot. Default value is 10.
@@ -955,7 +955,7 @@ plotHighestExprs <- function(object, col_by_variable = "total_features", n = 50,
 #' plotExplanatoryVariables(example_sce, variables=vars)
 #'
 plotExplanatoryVariables <- function(object, method = "density",
-                                     exprs_values = "exprs", nvars_to_plot = 10,
+                                     exprs_values = "logcounts", nvars_to_plot = 10,
                                      min_marginal_r2 = 0, variables = NULL,
                                      return_object = FALSE, theme_size = 10,
                                      ...) {
@@ -964,7 +964,7 @@ plotExplanatoryVariables <- function(object, method = "density",
     ## Checking arguments for expression values
     # exprs_values <- match.arg(
     #     exprs_values,
-    #     choices = c("exprs", "norm_exprs", "stand_exprs", "norm_exprs",
+    #     choices = c("logcounts", "norm_exprs", "stand_exprs", "norm_exprs",
     #                 "counts", "norm_counts", "tpm", "norm_tpm", "fpkm",
     #                 "norm_fpkm", "cpm", "norm_cpm"))
     exprs_mat <- assay(object, exprs_values)
@@ -1441,14 +1441,14 @@ plotQC <- function(object, type = "highest-expression", ...) {
 #' drop_genes <- apply(exprs(example_sce), 1, function(x) {var(x) == 0})
 #' example_sce <- example_sce[!drop_genes, ]
 #'
-#' plotRLE(example_sce, list(exprs = "exprs", counts = "counts"), c(TRUE, FALSE), 
+#' plotRLE(example_sce, list(exprs = "logcounts", counts = "counts"), c(TRUE, FALSE), 
 #'        colour_by = "Mutation_Status", style = "minimal")
 #'
-#' plotRLE(example_sce, list(exprs = "exprs", counts = "counts"), c(TRUE, FALSE), 
+#' plotRLE(example_sce, list(exprs = "logcounts", counts = "counts"), c(TRUE, FALSE), 
 #'        colour_by = "Mutation_Status", style = "full",
 #'        outlier.alpha = 0.1, outlier.shape = 3, outlier.size = 0)
 #' 
-plotRLE <- function(object, exprs_mats = list(exprs = "exprs"), exprs_logged = c(TRUE),
+plotRLE <- function(object, exprs_mats = list(exprs = "logcounts"), exprs_logged = c(TRUE),
                    colour_by = NULL, style = "minimal", legend = "auto", 
                    order_by_colour = TRUE, ncol = 1,  ...) {
               .plotRLE(object, exprs_mats = exprs_mats, exprs_logged = exprs_logged,
@@ -1456,7 +1456,7 @@ plotRLE <- function(object, exprs_mats = list(exprs = "exprs"), exprs_logged = c
                        order_by_colour = order_by_colour, ncol = ncol, style = style, ...)
           }
 
-.plotRLE <- function(object, exprs_mats = list(exprs = "exprs"), exprs_logged = c(TRUE),
+.plotRLE <- function(object, exprs_mats = list(exprs = "logcounts"), exprs_logged = c(TRUE),
                     colour_by = NULL, legend = "auto", order_by_colour = TRUE, ncol = 1,
                     style = "minimal", ...) {
     if (any(is.null(names(exprs_mats))) || any(names(exprs_mats) == ""))
@@ -1466,7 +1466,7 @@ plotRLE <- function(object, exprs_mats = list(exprs = "exprs"), exprs_logged = c
     style <- match.arg(style, c("full", "minimal"))
     ## Check arguments are valid
     colour_by_out <- .choose_vis_values(object, colour_by, cell_control_default = TRUE,
-                                        check_features = TRUE, exprs_values = "exprs")
+                                        check_features = TRUE, exprs_values = "logcounts")
     colour_by <- colour_by_out$name
     colour_by_vals <- colour_by_out$val
     ncells <- NULL


### PR DESCRIPTION
`exprs()` now diverts to extracting `"logcounts"`. Further note that `GET_FUN` and `SET_FUN` are strictly internal, they don't need to be documented. Only the additional accessors `norm_exprs()`, `stand_exprs()` and `fpkm()` need documentation.